### PR TITLE
DOC-3853: Update/add support_url attribute

### DIFF
--- a/playbooks/site-local-pulsar-connector.yaml
+++ b/playbooks/site-local-pulsar-connector.yaml
@@ -35,7 +35,7 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
 
-    support_url: 'https://houston.datastax.com/hc/requests/new'
+    support_url: 'https://support.datastax.com'
     astra_docs_base_url: 'https://docs.datastax.com/en/astra/docs'
 
     # The "glossary-url" attribute below is used by writers when linking to a

--- a/playbooks/site-publish-pulsar-connector.yaml
+++ b/playbooks/site-publish-pulsar-connector.yaml
@@ -40,7 +40,7 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
 
-    support_url: 'https://houston.datastax.com/hc/requests/new'
+    support_url: 'https://support.datastax.com'
     astra_docs_base_url: 'https://docs.datastax.com/en/astra/docs'
 
     # The "glossary-url" attribute below is used by writers when linking to a


### PR DESCRIPTION
**JIRA:** https://datastax.jira.com/browse/DOC-3853

This change updates/adds the `support_url` attribute with the correct link to the DataStax Support website.