### PR TITLE
DOc-5089 - Embedded Java driver config update

### DIFF
--- a/docs-src/pulsar-sink-core/modules/ROOT/pages/cfgPulsarSettingJavaDriverConfig.adoc
+++ b/docs-src/pulsar-sink-core/modules/ROOT/pages/cfgPulsarSettingJavaDriverConfig.adoc
@@ -1,7 +1,9 @@
-= Pass Pulsar Connector settings directly to the DataStax Java driver
+= Pass Pulsar Connector settings directly to the Java driver
 :page-tag: pulsar-connector,dev,develop,pulsar,java
 
-In your DataStax Apache Pulsar(TM) Connector configuration file, you can directly pass settings to the DataStax Java driver by using the `datastax-java-driver` prefix.
+//Author's note: pulsar-sink uses an embedded Java driver. As of 1.6.14, it uses 4.16.0 (https://github.com/datastax/pulsar-sink/blob/master/pom.xml#L46), which is a pre-donation "DataStax Java driver" version.
+
+In your DataStax Apache Pulsar(TM) Connector configuration file, you can pass settings directly to the embedded Cassandra Java driver by using the `datastax-java-driver` prefix.
 For example:
 
 [source,console]
@@ -11,12 +13,7 @@ datastax-java-driver.basic.request.consistency=ALL
 
 == Mapping Pulsar Connector settings to Java driver properties
 
-The following table identifies functionally equivalent DataStax Apache Pulsar Connector and DataStax Java driver settings.
-
-NOTE: If you define both in your configuration, the Pulsar Connector setting take precedence over the `datastax-java-driver.property-name`.
-If you do not provide either in your configuration, Pulsar Connector defaults are in effect.
-
-For information about the Java properties, refer to the https://docs.datastax.com/en/developer/java-driver-dse/2.3/manual/core/configuration/[DataStax Java driver documentation.] For information about the Pulsar Connector settings, refer to xref:cfgRefPulsarDseConnection.adoc[].
+The following table lists DataStax Apache Pulsar Connector settings and the functionally equivalent Java driver settings:
 
 |===
 | DataStax Apache Pulsar Connector setting | Using datastax-java-driver prefix
@@ -43,9 +40,19 @@ For information about the Java properties, refer to the https://docs.datastax.co
 | `datastax-java-driver.advanced.metrics.session.cql-requests.highest-latency`
 |===
 
-There is a difference between the Pulsar Connector's `contactPoints` setting and the Java driver's `datastax-java-driver.basic.contact-points`.
-For `contactPoints`, the value of the `port` is appended to every host provided by this setting.
-For `datastax-java-driver.basic.contact-points`, you must provide the fully qualified contact points (`host:port`).
+== Precedence of equivalent settings
+
+If you define both in your configuration, the Pulsar Connector setting takes precedence over the equivalent `datastax-java-driver.*` setting.
+
+If you don't specify either setting in your configuration, then the default value for the Pulsar Connector setting is used.
+
+== Difference between contact points settings
+
+There is a difference between the Pulsar Connector's `contactPoints` setting and the Java driver's `datastax-java-driver.basic.contact-points`:
+
+* For `contactPoints`, the value of the `port` is appended to every host provided by this setting.
+
+* For `datastax-java-driver.basic.contact-points`, you must provide the fully qualified contact points (`host:port`).
 
 By passing in the Java driver's setting, this option gives you more configuration flexibility because you can specify a different port for each host.
 Example:
@@ -57,7 +64,7 @@ datastax-java-driver.basic.contact-points = 127.0.0.1:9042, 127.0.0.2:90
 
 == Conversion of Java driver properties of type List to TypeSafe Config
 
-The following properties that are of type `List`, which you could pass into the driver from your Pulsar Connector configuration via the `datastax-java-driver` prefix, are converted by the DataStax Java driver to the `TypeSafe Config` format.
+The following properties that are of type `List`, which you could pass into the driver from your Pulsar Connector configuration via the `datastax-java-driver` prefix, are converted by the Java driver to the `https://docs.datastax.com/en/developer/java-driver/4.16/manual/core/configuration/index.html#default-implementation-typesafe-config[TypeSafe Config]` format:
 
 * `datastax-java-driver.advanced.ssl-engine-factory.cipher-suites`
 * `datastax-java-driver.advanced.metrics.node.enabled`
@@ -74,4 +81,8 @@ datastax-java-driver.advanced.metrics.session.enabled.0=a
 datastax-java-driver.advanced.metrics.session.enabled.1=b
 ----
 
-For more information, refer to the https://docs.datastax.com/en/developer/java-driver/4.3/manual/core/configuration/reference/[Java driver reference configuration] topic.
+== See also
+
+* xref:cfgRefPulsarDseConnection.adoc[]
+* https://docs.datastax.com/en/developer/java-driver/4.16/manual/core/configuration/reference/index.html[Java driver reference.conf]
+* https://docs.datastax.com/en/developer/java-driver/4.16/manual/core/configuration/index.html[Java driver configuration]


### PR DESCRIPTION
pulsar-sink uses an embedded Java driver. As of 1.6.14, it uses 4.16.0 (https://github.com/datastax/pulsar-sink/blob/master/pom.xml#L46), which is a pre-donation "DataStax Java driver" version.

I changed the prefix to "embedded Java driver", cleaned the page up a little, and updated the driver docs links to the embedded versions (4.16). 

https://d5rxiv0do0q3v.cloudfront.net/doc-5089/pulsar-connector/cfgPulsarSettingJavaDriverConfig.html