### PR TITLE
DOC-5507 downloads.datastax.com

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -13,6 +13,7 @@ asciidoc:
     pulsar-reg: 'Apache Pulsar(TM)'
     pulsar: 'Apache Pulsar'
     pulsar-short: 'Pulsar'
+    pulsar-sink-repo: 'https://github.com/datastax/pulsar-sink'
     astra: 'Astra'
     astra-db: 'Astra DB'
     scb: 'Secure Connect Bundle (SCB)'

--- a/modules/ROOT/pages/opsPulsarDeleteConnector.adoc
+++ b/modules/ROOT/pages/opsPulsarDeleteConnector.adoc
@@ -37,7 +37,7 @@ Shutdown is in progress... Please wait...
 Shutdown completed.
 ----
 
-. Remove the {product-short} NAR from your {pulsar-short} `connectors` directory:
+. Remove the {product-short} `.nar` file from your {pulsar-short} `connectors` directory:
 +
 [source,bash]
 ----

--- a/modules/ROOT/pages/pulsarInstall.adoc
+++ b/modules/ROOT/pages/pulsarInstall.adoc
@@ -52,44 +52,26 @@ The {product-short} framework automatically rebalances the load when workers are
 Perform the following steps on a {pulsar-short} Connect node running {pulsar} 2.7.0 or later.
 If you need to install {pulsar-short}, see xref:ROOT:pulsarQuickStart.adoc[].
 
-. Download the {product-short} tar file from the https://downloads.datastax.com/#apc[{company} downloads site].
-
-. Extract the files, replacing **VERSION** with the version number of the tar file you downloaded:
-+
-[source,bash,subs="+quotes"]
-----
-tar zxf cassandra-enhanced-pulsar-sink-**VERSION**.tar.gz
-----
-+
-The following files are unpacked into a directory named after the tar file, such as `cassandra-enhanced-pulsar-sink-1.4.0`:
-+
-[source,console]
-----
-LICENSE.txt
-README.md
-THIRD-PARTY.txt
-conf/example.yml
-cassandra-enhanced-pulsar-sink-1.4.0.nar
-----
+. Download the {product-short} `.nar` file from the {pulsar-sink-repo}/releases[{product-short} repository].
 
 . In your {pulsar-short} `home` directory, find the `connectors` directory.
 If there isn't a `connectors` directory, create one.
 
-. Move the {product-short} NAR file to the {pulsar-short} `connectors` directory:
+. Move the {product-short} `.nar` file to the {pulsar-short} `connectors` directory:
 +
 [source,bash]
 ----
 mv installation_location/cassandra-enhanced-pulsar-sink-1.4.0.nar pulsar_home/connectors
 ----
 
-. Copy the sample configuration file `example.yml` from `cassandra-enhanced-pulsar-sink-**VERSION**/conf/` to your {pulsar-short} `config` directory.
+. Download and move the {pulsar-sink-repo}/blob/master/pulsar-dist/conf/example.yml[sample configuration file `example.yml`] to your {pulsar-short} `config` directory.
 +
 If you plan to create multiple sinks from this connector, give your configuration file a unique name.
 
 . Edit the configuration file as necessary using the information provided in this documentation.
 For example, for information about connection, authentication, and encryption parameters, see xref:ROOT:cfgRefPulsarDseConnection.adoc[].
 
-. Ensure that the user running {pulsar-short} has permission to access the configuration and NAR files.
+. Ensure that the user running {pulsar-short} has permission to access the configuration and `.nar` files.
 
 == Start {pulsar-short} with the {product-short}
 

--- a/modules/ROOT/pages/pulsarQuickStart.adoc
+++ b/modules/ROOT/pages/pulsarQuickStart.adoc
@@ -70,21 +70,14 @@ wget https://archive.apache.org/dist/pulsar/pulsar-2.7.0/apache-pulsar-2.7.0-bin
 tar xvfz apache-pulsar-2.7.0-bin.tar.gz
 ----
 
-. Download the {product} tar file from the https://downloads.datastax.com/#apc[{company} downloads site].
+. Download the {product} `.nar` file from the {pulsar-sink-repo}/releases[{product-short} repository].
 +
 For more information about system requirements for the {product-short}, see xref:ROOT:pulsarInstall.adoc[].
-
-. Extract the files, replacing **VERSION** with the version number of the tar file you downloaded:
-+
-[source,bash,subs="+quotes"]
-----
-tar zxf cassandra-enhanced-pulsar-sink-**VERSION**.tar.gz
-----
 
 . In your {pulsar-short} `home` directory, find the `connectors` directory.
 If there isn't a `connectors` directory, create one.
 
-. Move the {product-short} NAR file to the {pulsar-short} `connectors` directory:
+. Move the {product-short} `.nar` file to the {pulsar-short} `connectors` directory:
 +
 [source,bash]
 ----
@@ -157,7 +150,7 @@ configs:
 
 . If your cluster has authentication enabled, you want to use an SSL-encrypted connection, or your cluster isn't compatible with the connection properties in `qs.yml`, you must edit the configuration file as explained in xref:ROOT:cfgRefPulsarDseConnection.adoc[].
 
-. Ensure that the user running {pulsar-short} has permission to access the configuration and NAR files.
+. Ensure that the user running {pulsar-short} has permission to access the configuration and `.nar` files.
 
 == Run {pulsar-short} with the {product-short}
 


### PR DESCRIPTION
* Replace 2 downloads.datastax.com links with links to the pulsar-sink releases page. The `.nar` can be downloaded from there.
* Link to the `example.yml` in the pulsar-sink repo rather than relying on a file bundled with the tarball.
* Change "NAR" to "`.nar` file" for consistency.